### PR TITLE
[UPD] Task-12-Namespace for SEtLocaleMiddlewareTest

### DIFF
--- a/tests/Feature/API/V1/CurrentUserTest.php
+++ b/tests/Feature/API/V1/CurrentUserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\API\V1;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/API/V1/Http/Middleware/SetLocaleMiddlewareTest.php
+++ b/tests/Feature/API/V1/Http/Middleware/SetLocaleMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\API\V1\Http\Middleware;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;


### PR DESCRIPTION
Problem
* Class Tests\Feature\SetLocaleMiddlewareTest located in ./tests/Feature/API/V1/Http/Middleware/SetLocaleMiddlewareTest.php  and CurrentUserTest do not comply with psr-4 autoloading standard.

Solution
* Correct the namespace