### PR TITLE
[BUG] Task-14-Add fillable and validation for artist_id for LP

### DIFF
--- a/app/Http/Requests/API/V1/StoreLPRequest.php
+++ b/app/Http/Requests/API/V1/StoreLPRequest.php
@@ -24,6 +24,7 @@ class StoreLPRequest extends FormRequest
         return [
             'title' => 'required|string|max:255|unique:App\Models\V1\LP',
             'description' => 'required|string|max:255',
+            'artist_id' => 'nullable|integer|exists:App\Models\V1\Artist,id',
         ];
     }
 }

--- a/app/Http/Requests/API/V1/UpdateLPRequest.php
+++ b/app/Http/Requests/API/V1/UpdateLPRequest.php
@@ -24,6 +24,7 @@ class UpdateLPRequest extends FormRequest
         return [
             'title' => 'required|string|max:255|unique:App\Models\V1\LP,title,'.$this->lp,
             'description' => 'required|string|max:255',
+            'artist_id' => 'nullable|integer|exists:App\Models\V1\Artist,id',
         ];
     }
 }

--- a/app/Models/V1/LP.php
+++ b/app/Models/V1/LP.php
@@ -17,6 +17,7 @@ class LP extends BaseModel
     protected $fillable = [
         'title',
         'description',
+        'artist_id',
     ];
 
     public function artist()

--- a/tests/Feature/API/V1/Http/Controllers/LPControllerTest.php
+++ b/tests/Feature/API/V1/Http/Controllers/LPControllerTest.php
@@ -29,10 +29,12 @@ class LPControllerTest extends TestCase
     public function testStoreCreatesNewLPAndReturnsIt()
     {
         $user = User::factory()->create();
+        $artist = Artist::factory()->create();
 
         $lpData = [
             'title' => 'New LP',
             'description' => 'LP description',
+            'artist_id' => $artist->id,
         ];
 
         $this->actingAs($user, 'sanctum')->postJson('/api/v1/lps', $lpData);
@@ -58,9 +60,12 @@ class LPControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $lp = LP::factory()->create();
+        $artist = Artist::factory()->create();
+
         $updatedData = [
             'title' => 'Updated LP',
             'description' => 'Updated LP description',
+            'artist_id' => $artist->id,
         ];
 
         $this->actingAs($user, 'sanctum')->putJson("/api/v1/lps/{$lp->id}", $updatedData);

--- a/tests/Unit/API/V1/Models/LPModelTest.php
+++ b/tests/Unit/API/V1/Models/LPModelTest.php
@@ -32,6 +32,6 @@ class LPModelTest extends TestCase
     public function testFillable()
     {
         $lp = new LP();
-        $this->assertEquals(['title', 'description'], $lp->getFillable());
+        $this->assertEquals(['title', 'description', 'artist_id'], $lp->getFillable());
     }
 }


### PR DESCRIPTION
Problem
* No artist_id is allowed on creating/updating LP

Solution
* Update/improve from requests for update/create LP
* Add artist_id as fillable in LP model